### PR TITLE
Added proper index for torch and updated Pipfile*

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -3,6 +3,11 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
 
+[[source]]
+url = "https://download.pytorch.org/whl/cpu"
+verify_ssl = true
+name = "pytorch"
+
 [packages]
 pylint = "*"
 black = "*"
@@ -12,7 +17,7 @@ pytest-flask = "*"
 pymongo = "*"
 pybase62 = "*"
 pytest = "*"
-torch = "*"
+torch = {version="*", index="pytorch"}
 gunicorn = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f1debe399b9f50f3d71abebd146d46972dcc1d0e038473eb319eb5210b0185c0"
+            "sha256": "36a4e73f7f56b1f53c1b87730c967d77b3b279dc1aef993d91c9485977241c5a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -11,6 +11,11 @@
             {
                 "name": "pypi",
                 "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            },
+            {
+                "name": "pytorch",
+                "url": "https://download.pytorch.org/whl/cpu",
                 "verify_ssl": true
             }
         ]
@@ -195,11 +200,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9",
-                "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"
+                "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14",
+                "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.1.3"
+            "version": "==1.2.0"
         },
         "filelock": {
             "hashes": [
@@ -237,11 +242,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
-                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
+                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.4"
+            "version": "==3.6"
         },
         "iniconfig": {
             "hashes": [
@@ -804,30 +809,18 @@
         },
         "torch": {
             "hashes": [
-                "sha256:0a7a9da0c324409bcb5a7bdad1b4e94e936d21c2590aaa7ac2f63968da8c62f7",
-                "sha256:1d70920da827e2276bf07f7ec46958621cad18d228c97da8f9c19638474dbd52",
-                "sha256:1e1e5faddd43a8f2c0e0e22beacd1e235a2e447794d807483c94a9e31b54a758",
-                "sha256:1e3cbecfa5a7314d828f4a37b0c286714dc9aa2e69beb7a22f7aca76567ed9f4",
-                "sha256:29e3b90a8c281f6660804a939d1f4218604c80162e521e1e6d8c8557325902a0",
-                "sha256:2dc9f312fc1fa0d61a565a0292ad73119d4b74c9f8b5031b55f8b4722abca079",
-                "sha256:403f1095e665e4f35971b43797a920725b8b205723aa68254a4050c6beca29b6",
-                "sha256:5ebc43f5355a9b7be813392b3fb0133991f0380f6f0fcc8218d5468dc45d1071",
-                "sha256:61b51b33c61737c287058b0c3061e6a9d3c363863e4a094f804bc486888a188a",
-                "sha256:715b50d8c1de5da5524a68287eb000f73e026e74d5f6b12bc450ef6995fcf5f9",
-                "sha256:84fefd63356416c0cd20578637ccdbb82164993400ed17b57c951dd6376dcee8",
-                "sha256:98fea993639b0bb432dfceb7b538f07c0f1c33386d63f635219f49254968c80f",
-                "sha256:9ca0fcbf3d5ba644d6a8572c83a9abbdf5f7ff575bc38529ef6c185a3a71bde9",
-                "sha256:a70593806f1d7e6b53657d96810518da0f88ef2608c98a402955765b8c79d52c",
-                "sha256:b31230bd058424e56dba7f899280dbc6ac8b9948e43902e0c84a44666b1ec151",
-                "sha256:bd95cee8511584b67ddc0ba465c3f1edeb5708d833ee02af1206b4486f1d9096",
-                "sha256:d56b032176458e2af4709627bbd2c20fe2917eff8cd087a7fe313acccf5ce2f1",
-                "sha256:db67e8725c76f4c7f4f02e7551bb16e81ba1a1912867bc35d7bb96d2be8c78b4",
-                "sha256:e312f7e82e49565f7667b0bbf9559ab0c597063d93044740781c02acd5a87978",
-                "sha256:e76bf3c5c354874f1da465c852a2fb60ee6cbce306e935337885760f080f9baa"
+                "sha256:16e6cdb1991ff1f15f469b12fffb5b20f00b1ecff8c1073c23c7760fba90fcbc",
+                "sha256:23be0cb945970443c97d4f9ea61ed03b27f924d835de689dd4134f30966c13f7",
+                "sha256:8e4e47aa4a004d2f5edd516b296da6fba07981ae9d1fc0da862abf651dc07d96",
+                "sha256:9399a8dfe4833bb544e7a0c332c47db1e389a06b4ae5ac9b3b167d863adc95d9",
+                "sha256:b09d431c8e53511b6c3624f1d79cce9cd28f4c27ca20c5a49e4dcc1f9e7377e5",
+                "sha256:b2cc98815251f8a2d102c2f8f4afe8304c2df61ce9c237198032c7903d97fdbb",
+                "sha256:d83b13cb17544f9851cc31fed197865eae0c0f5d32df9d8d6d8535df7d2e5109",
+                "sha256:d8e19bb465e1fa15f3231ff57bbf0a673e5dcaca39eee4f58a4be7832b80c9da"
             ],
-            "index": "pypi",
+            "index": "pytorch",
             "markers": "python_full_version >= '3.8.0'",
-            "version": "==2.1.1"
+            "version": "==2.1.1+cpu"
         },
         "tqdm": {
             "hashes": [
@@ -842,7 +835,7 @@
                 "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
                 "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_version >= '3.8'",
             "version": "==4.8.0"
         },
         "urllib3": {


### PR DESCRIPTION
We are planning to use a CPU version of PyTorch. When running `docker build` and attempting to install `torch` from PyPI, it won't work. I switched the source of PyTorch to an index provided by the PyTorch team.